### PR TITLE
👌 IMPROVE: Tabs useKeyboardNavigation a11y spec match

### DIFF
--- a/apps/interunit-dot-dev/app/ui/docs/composites/tabs/page.tsx
+++ b/apps/interunit-dot-dev/app/ui/docs/composites/tabs/page.tsx
@@ -25,7 +25,7 @@ const TabsPage = () => {
       />
       <ComponentDisplay className="mb-12">
         <Tabs defaultValue="home">
-          <P.BX el="div" className="flex gap-2">
+          <Tabs.TriggerList el="div" className="flex gap-2">
             <Tabs.Trigger
               value={'home'}
               aria-label="View the home content"
@@ -47,7 +47,7 @@ const TabsPage = () => {
             >
               <Button color="bg-secondary">Contact</Button>
             </Tabs.Trigger>
-          </P.BX>
+          </Tabs.TriggerList>
           <div className="w-full border-border border-[2px] rounded p-4 mt-4">
             <Tabs.Content value="home">Home</Tabs.Content>
             <Tabs.Content value="about">About</Tabs.Content>

--- a/packages/a11y/src/hooks/useKeyboardNavigation.tsx
+++ b/packages/a11y/src/hooks/useKeyboardNavigation.tsx
@@ -48,61 +48,13 @@ function useKeyboardNavigation(params: UseKeyboardNavigationParams) {
   }
 
   //
-  // Move focus when user wants the focus to leave
-  // the current focusable elements
-  //
-  function moveFocusOutside({direction}: {direction: 'forward' | 'backward'}) {
-    const insideFocusableElements =
-      params.ref.current?.querySelectorAll(`[${params.attribute}]`) ?? []
-
-    const outsideFocusableElements = document.body.querySelectorAll(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    )
-
-    const edgeOfInsideFocusableElements = Array.from(
-      outsideFocusableElements
-    ).indexOf(
-      direction === 'forward'
-        ? insideFocusableElements[insideFocusableElements.length - 1]
-        : insideFocusableElements[0]
-    )
-
-    const edgeOfOutsideFocusableElements =
-      direction === 'forward' ? outsideFocusableElements.length - 1 : 0
-
-    if (edgeOfInsideFocusableElements === edgeOfOutsideFocusableElements) {
-      const nextIndex =
-        direction === 'forward' ? 0 : outsideFocusableElements.length - 1
-      const nextElement = outsideFocusableElements[nextIndex] as HTMLElement
-      nextElement?.focus()
-      return nextElement
-    }
-
-    const nextIndex =
-      direction === 'forward'
-        ? edgeOfInsideFocusableElements + 1
-        : edgeOfInsideFocusableElements - 1
-
-    const nextElement = outsideFocusableElements[nextIndex] as HTMLElement
-    nextElement?.focus()
-  }
-
-  //
   // Move focus when user interacts with keyboard
   //
   function handleKeyDown(event: KeyboardEvent) {
     const orientation =
       params.ref.current?.getAttribute('aria-orientation') ?? 'horizontal'
 
-    if (event.key === 'Tab') {
-      event.preventDefault()
-      if (event.shiftKey) {
-        moveFocusOutside({direction: 'backward'})
-      }
-      if (!event.shiftKey) {
-        moveFocusOutside({direction: 'forward'})
-      }
-    }
+    if (!(event.target as HTMLElement)?.hasAttribute(params.attribute)) return
 
     if (orientation === 'horizontal') {
       if (event.key === 'ArrowRight') {

--- a/packages/tabs/src/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs.test.tsx
@@ -1,4 +1,4 @@
-import {axe, fireEvent, render, userEvent, waitFor} from '@interunit/jest/web'
+import {axe, fireEvent, render, userEvent} from '@interunit/jest/web'
 
 import {Tabs} from './Tabs'
 
@@ -13,6 +13,17 @@ const TabsComponent = ({defaultValue = '1'}) => {
       <Tabs.Content value="1">Tab 1 content</Tabs.Content>
       <Tabs.Content value="2">Tab 2 content</Tabs.Content>
       <Tabs.Content value="3">Tab 3 content</Tabs.Content>
+    </Tabs>
+  )
+}
+const TabsComponentWithoutContent = ({defaultValue = '1'}) => {
+  return (
+    <Tabs defaultValue={defaultValue}>
+      <Tabs.TriggerList>
+        <Tabs.Trigger value="1">Tab 1</Tabs.Trigger>
+        <Tabs.Trigger value="2">Tab 2</Tabs.Trigger>
+        <Tabs.Trigger value="3">Tab 3</Tabs.Trigger>
+      </Tabs.TriggerList>
     </Tabs>
   )
 }
@@ -88,11 +99,11 @@ describe('Tabs', () => {
 
     expect(outside1).toHaveFocus()
 
-    await user.keyboard('{Tab}')
+    await user.tab()
 
     expect(tab1).toHaveFocus()
   })
-  test('shift tabbing into Tabs selects active tab', async () => {
+  test('tabbing into Tabs selects active tab', async () => {
     const user = userEvent.setup()
     const {container} = render(
       <div>
@@ -108,7 +119,7 @@ describe('Tabs', () => {
 
     expect(outside1).toHaveFocus()
 
-    await user.keyboard('{Tab}')
+    await user.tab()
 
     expect(tab2).toHaveFocus()
   })
@@ -120,14 +131,61 @@ describe('Tabs', () => {
       </div>
     )
     const tab2 = container.querySelector('[data-tab-value="2"]')
-    const tab2Content = container.querySelector('[data-tab-value="2"]')
+    const tab2Content = container.querySelector('[data-tab-content="2"]')
 
     tab2Content.focus()
 
     expect(tab2Content).toHaveFocus()
 
-    await user.keyboard('{Shift>}Tab{/Shift}')
+    await user.tab({shift: true})
 
-    await waitFor(() => expect(tab2).toHaveFocus())
+    expect(tab2).toHaveFocus()
+  })
+  test('tabbing from Tabs trigger focuses content', async () => {
+    const user = userEvent.setup()
+    const {container} = render(
+      <div>
+        <TabsComponent defaultValue={'2'} />
+      </div>
+    )
+    const tab2 = container.querySelector('[data-tab-value="2"]')
+    const tab2Content = container.querySelector('[data-tab-content="2"]')
+
+    tab2.focus()
+
+    expect(tab2).toHaveFocus()
+
+    await user.tab()
+
+    expect(tab2Content).toHaveFocus()
+  })
+  test('works without Tabs.Content', async () => {
+    const user = userEvent.setup()
+    const {container} = render(
+      <div>
+        <button data-outside="1">Button</button>
+        <TabsComponentWithoutContent defaultValue={'2'} />
+        <button data-outside="2">Button</button>
+      </div>
+    )
+    const outside1 = container.querySelector('[data-outside="1"]')
+    const outside2 = container.querySelector('[data-outside="2"]')
+    const tab2 = container.querySelector('[data-tab-value="2"]')
+
+    tab2.focus()
+
+    expect(tab2).toHaveFocus()
+
+    await user.tab()
+
+    expect(outside2).toHaveFocus()
+
+    await user.tab({shift: true})
+
+    expect(tab2).toHaveFocus()
+
+    await user.tab({shift: true})
+
+    expect(outside1).toHaveFocus()
   })
 })

--- a/packages/tabs/src/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs.test.tsx
@@ -1,4 +1,4 @@
-import {axe, fireEvent, render, userEvent} from '@interunit/jest/web'
+import {axe, fireEvent, render, userEvent, waitFor} from '@interunit/jest/web'
 
 import {Tabs} from './Tabs'
 
@@ -88,7 +88,7 @@ describe('Tabs', () => {
 
     expect(outside1).toHaveFocus()
 
-    await user.keyboard('{tab}')
+    await user.keyboard('{Tab}')
 
     expect(tab1).toHaveFocus()
   })
@@ -108,7 +108,7 @@ describe('Tabs', () => {
 
     expect(outside1).toHaveFocus()
 
-    await user.keyboard('{tab}')
+    await user.keyboard('{Tab}')
 
     expect(tab2).toHaveFocus()
   })
@@ -126,8 +126,8 @@ describe('Tabs', () => {
 
     expect(tab2Content).toHaveFocus()
 
-    await user.keyboard('{Shift}{tab}')
+    await user.keyboard('{Shift>}Tab{/Shift}')
 
-    expect(tab2).toHaveFocus()
+    await waitFor(() => expect(tab2).toHaveFocus())
   })
 })

--- a/packages/tabs/src/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs.test.tsx
@@ -1,4 +1,4 @@
-import {axe, fireEvent, render, userEvent} from '@interunit/jest/web'
+import {axe, render, userEvent} from '@interunit/jest/web'
 
 import {Tabs} from './Tabs'
 
@@ -49,6 +49,8 @@ describe('Tabs', () => {
     expect(tab3Content).toHaveAttribute('hidden')
   })
   test('prev and next keyboard navigation works', async () => {
+    const user = userEvent.setup()
+
     const {container} = render(<TabsComponent />)
     const tab1 = container.querySelector('[data-tab-value="1"]')
     const tab2 = container.querySelector('[data-tab-value="2"]')
@@ -56,19 +58,21 @@ describe('Tabs', () => {
 
     tab1.focus()
 
-    fireEvent.keyDown(tab1, {key: 'ArrowRight'})
+    await user.keyboard('{ArrowRight}')
 
     expect(tab1).toHaveAttribute('data-state', 'inactive')
     expect(tab2).toHaveAttribute('data-state', 'active')
     expect(tab1Content).toHaveAttribute('hidden')
 
-    fireEvent.keyDown(tab2, {key: 'ArrowLeft'})
+    await user.keyboard('{ArrowLeft}')
 
     expect(tab1).toHaveAttribute('data-state', 'active')
     expect(tab2).toHaveAttribute('data-state', 'inactive')
     expect(tab1Content).not.toHaveAttribute('hidden')
   })
   test('keyboard navigation looping works', async () => {
+    const user = userEvent.setup()
+
     const {container} = render(<TabsComponent />)
     const tab1 = container.querySelector('[data-tab-value="1"]')
     const tab3 = container.querySelector('[data-tab-value="3"]')
@@ -76,7 +80,7 @@ describe('Tabs', () => {
 
     tab1.focus()
 
-    fireEvent.keyDown(tab1, {key: 'ArrowLeft'})
+    await user.keyboard('{ArrowLeft}')
 
     expect(tab1).toHaveAttribute('data-state', 'inactive')
     expect(tab3).toHaveAttribute('data-state', 'active')

--- a/packages/tabs/src/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs.test.tsx
@@ -92,7 +92,7 @@ describe('Tabs', () => {
 
     expect(tab1).toHaveFocus()
   })
-  test.skip('shift tabbing into Tabs selects active tab', async () => {
+  test('shift tabbing into Tabs selects active tab', async () => {
     const user = userEvent.setup()
     const {container} = render(
       <div>
@@ -112,7 +112,7 @@ describe('Tabs', () => {
 
     expect(tab2).toHaveFocus()
   })
-  test.skip('shift tabbing into Tabs selects active tab', async () => {
+  test('shift tabbing into Tabs selects active tab', async () => {
     const user = userEvent.setup()
     const {container} = render(
       <div>

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -69,10 +69,10 @@ type TabsTriggerListProps = Omit<
 }
 
 const TabsTriggerList = React.forwardRef(function TabsTriggerList(
-  props: TabsTriggerListProps,
+  {asChild, ...props}: TabsTriggerListProps,
   forwardedRef: React.Ref<TabsTriggerListProps>
 ) {
-  const TriggerList = props.asChild ? Child : P.BX
+  const TriggerList = asChild ? Child : P.BX
   return (
     <TriggerList el="div" role="tablist" ref={forwardedRef} {...props}>
       {props.children}
@@ -92,11 +92,11 @@ type TabsTriggerProps<T> = Omit<
 
 const TabsTrigger: React.FC<TabsTriggerProps<unknown>> = React.forwardRef(
   function TabsTrigger<V>(
-    {el = 'button', value, ...props}: TabsTriggerProps<V>,
+    {el = 'button', value, asChild, ...props}: TabsTriggerProps<V>,
     forwardedRef: React.Ref<TabsTriggerProps<V>>
   ) {
     const {value: currentValue, setValue} = React.useContext(TabsContext)
-    const Button = props.asChild ? Child : P.BT
+    const Button = asChild ? Child : P.BT
 
     return (
       <Button
@@ -105,6 +105,7 @@ const TabsTrigger: React.FC<TabsTriggerProps<unknown>> = React.forwardRef(
         data-tab
         data-tab-value={value}
         data-state={currentValue === value ? 'active' : 'inactive'}
+        tabIndex={currentValue === value ? 0 : -1}
         aria-selected={currentValue === value}
         {...props}
         ref={forwardedRef}
@@ -146,6 +147,7 @@ const TabsContent: React.FC<TabsContentProps<unknown>> = React.forwardRef(
         hidden={currentValue !== value}
         {...props}
         ref={forwardedRef}
+        tabIndex={0}
         onClick={() => {
           setValue && setValue(value)
         }}

--- a/packages/tabs/src/Tabs.tsx
+++ b/packages/tabs/src/Tabs.tsx
@@ -36,7 +36,7 @@ function Tabs<V>({el = 'div', ...props}: TabsProps<V>) {
 
   useKeyboardNavigation({
     ref: tabsContainerRef,
-    attribute: 'data-tab',
+    attribute: 'data-tab-trigger',
     onFocusChange: (focusedElement: HTMLElement) => {
       const tabValue = focusedElement.getAttribute('data-tab-value')
       if (tabValue) {
@@ -102,7 +102,7 @@ const TabsTrigger: React.FC<TabsTriggerProps<unknown>> = React.forwardRef(
       <Button
         el={el}
         role="tab"
-        data-tab
+        data-tab-trigger
         data-tab-value={value}
         data-state={currentValue === value ? 'active' : 'inactive'}
         tabIndex={currentValue === value ? 0 : -1}


### PR DESCRIPTION
Updates Tabs component so that tabbing into it focuses the current-active tab, not the first/last tab. Also makes the Tabs.Content focusable