### PR TITLE
🐛 FIX: Change export files of packages to point to the correct file

### DIFF
--- a/apps/interunit-dot-dev/CHANGELOG.md
+++ b/apps/interunit-dot-dev/CHANGELOG.md
@@ -1,5 +1,21 @@
 # interunit-dot-dev
 
+## 0.1.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @interunit/collapsible@0.0.15
+  - @interunit/primitives@0.0.19
+  - @interunit/responsive@0.0.13
+  - @interunit/combobox@0.0.13
+  - @interunit/popover@0.0.20
+  - @interunit/config@0.0.14
+  - @interunit/modal@0.0.15
+  - @interunit/a11y@0.0.17
+  - @interunit/form@0.0.11
+  - @interunit/tabs@0.0.11
+
 ## 0.1.5
 
 ### Patch Changes

--- a/apps/interunit-dot-dev/package.json
+++ b/apps/interunit-dot-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interunit-dot-dev",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/interunit-example-app/CHANGELOG.md
+++ b/apps/interunit-example-app/CHANGELOG.md
@@ -1,5 +1,19 @@
 # interunit-example-app
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @interunit/primitives@0.0.19
+  - @interunit/responsive@0.0.13
+  - @interunit/combobox@0.0.13
+  - @interunit/popover@0.0.20
+  - @interunit/config@0.0.14
+  - @interunit/modal@0.0.15
+  - @interunit/form@0.0.11
+  - @interunit/tabs@0.0.11
+
 ## 1.0.2
 
 ### Patch Changes

--- a/apps/interunit-example-app/package.json
+++ b/apps/interunit-example-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interunit-example-app",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.js",
   "scripts": {
     "dev:all": "expo start --dev-client",

--- a/packages/a11y/CHANGELOG.md
+++ b/packages/a11y/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @interunit/a11y
 
+## 0.0.17
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/primitives@0.0.19
+  - @interunit/config@0.0.14
+
 ## 0.0.16
 
 ### Patch Changes

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/a11y",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "A11y utilities to use in InterUnit",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/collapsible/CHANGELOG.md
+++ b/packages/collapsible/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @interunit/collapsible
 
+## 0.0.15
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/primitives@0.0.19
+  - @interunit/config@0.0.14
+  - @interunit/a11y@0.0.17
+
 ## 0.0.14
 
 ### Patch Changes

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/collapsible",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A component that expands and collapses content",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/combobox/CHANGELOG.md
+++ b/packages/combobox/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @interunit/combobox
 
+## 0.0.13
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/primitives@0.0.19
+  - @interunit/config@0.0.14
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -13,8 +13,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/combobox",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "description": "",
   "homepage": "https://github.com/interunit/ui#readme",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @interunit/config
 
+## 0.0.14
+
+### Patch Changes
+
+- Fixing package.json exports
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/config",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Handles all config for interactions between packages",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/crossplatform/CHANGELOG.md
+++ b/packages/crossplatform/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @interunit/crossplatform
 
+## 0.0.13
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/toolbox@0.0.13
+  - @interunit/config@0.0.14
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/crossplatform/package.json
+++ b/packages/crossplatform/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/crossplatform/package.json
+++ b/packages/crossplatform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/crossplatform",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Components and helpers to make cross-platform translations and development smooth",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/form/CHANGELOG.md
+++ b/packages/form/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @interunit/form
 
+## 0.0.11
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/primitives@0.0.19
+  - @interunit/config@0.0.14
+  - @interunit/a11y@0.0.17
+
 ## 0.0.10
 
 ### Patch Changes

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -13,8 +13,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/form",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "description": "Components for easily creating accessible forms",
   "homepage": "https://github.com/interunit/ui/tree/main/packages/form",

--- a/packages/modal/CHANGELOG.md
+++ b/packages/modal/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @interunit/modal
 
+## 0.0.15
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/primitives@0.0.19
+  - @interunit/config@0.0.14
+  - @interunit/a11y@0.0.17
+
 ## 0.0.14
 
 ### Patch Changes

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/modal",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A low-level component to help display content on top of the current page or view",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @interunit/popover
 
+## 0.0.20
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/crossplatform@0.0.13
+  - @interunit/primitives@0.0.19
+  - @interunit/toolbox@0.0.13
+  - @interunit/config@0.0.14
+  - @interunit/modal@0.0.15
+  - @interunit/a11y@0.0.17
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/popover",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "A popover component",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/primitives/CHANGELOG.md
+++ b/packages/primitives/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @interunit/primitives
 
+## 0.0.19
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/crossplatform@0.0.13
+  - @interunit/toolbox@0.0.13
+  - @interunit/config@0.0.14
+
 ## 0.0.18
 
 ### Patch Changes

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/primitives",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/responsive/CHANGELOG.md
+++ b/packages/responsive/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @interunit/responsive
 
+## 0.0.13
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/config@0.0.14
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/responsive",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Utilities to make cross-platform development a breeze 🍃",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/responsive/package.json
+++ b/packages/responsive/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/tabs/CHANGELOG.md
+++ b/packages/tabs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @interunit/tabs
 
+## 0.0.11
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/primitives@0.0.19
+  - @interunit/toolbox@0.0.13
+  - @interunit/config@0.0.14
+  - @interunit/a11y@0.0.17
+
 ## 0.0.10
 
 ### Patch Changes

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/tabs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Organizes content into easily switchable sections",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/toolbox/CHANGELOG.md
+++ b/packages/toolbox/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @interunit/toolbox
 
+## 0.0.13
+
+### Patch Changes
+
+- Fixing package.json exports
+- Updated dependencies
+  - @interunit/config@0.0.14
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@interunit/toolbox",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "A collection of helpers and utils ",
   "homepage": "https://github.com/interunit/ui#readme",
   "bugs": {

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -12,8 +12,8 @@
   },
   "license": "ISC",
   "author": "Kyle McDonald",
-  "main": "dist/index.cjs",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The `main` and `module` fields were pointing to the wrong file in the dist directory. This should fix that.